### PR TITLE
Attribution feature for the graphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ course/en/images/origami-menu-two.jpg
 
 Text to be displayed as an attribution, by default it is placed below the image, with CSS this can be changed, text can contain HTML tags, e.g.
 
-Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>
+Copyright © 2015 by &lt;b&gt;Lukasz 'Severiaan' Grela&lt;/b&gt;
 
 ##Limitations
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ You can use this setting to add custom classes to your template and LESS file.
 
 This defines the position of the component in the block. Values can be `full`, `left` or `right`. 
 
+####_showAttribution
+
+Boolean value that decides if the attribution text will be used.
+
 ####_graphic
 
-The image for this component is defined within this element. The _graphic element should contain only one value for `alt`, `title`, `large`, `medium` and `small`.
+The image for this component is defined within this element. The _graphic element should contain only one value for `alt`, `title`, `large`, `medium`, `small` and `attribution`.
 
 ####alt
 
@@ -75,6 +79,10 @@ course/en/images/origami-menu-two.jpg
 Enter a path to the image for small device width. Paths should be relative to the src folder, e.g.
 
 course/en/images/origami-menu-two.jpg
+
+####attribution
+
+Text to be displayed as an attribution, by default it is placed below the image, with CSS this can be changed.
 
 ##Limitations
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ course/en/images/origami-menu-two.jpg
 
 ####attribution
 
-Text to be displayed as an attribution, by default it is placed below the image, with CSS this can be changed.
+Text to be displayed as an attribution, by default it is placed below the image, with CSS this can be changed, text can contain HTML tags, e.g.
+
+Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>
 
 ##Limitations
 

--- a/example.json
+++ b/example.json
@@ -9,11 +9,13 @@
         "displayTitle":"Here is a graphic object",
         "body":"Hi everybody!",
         "instruction":"",
+        "_showAttribution":true,
         "_graphic": {
             "alt": "alt text",
             "title": "title text",
             "large": "http://cdn.lipstiq.com/wp-content/uploads/2013/07/minions-film.jpg",
             "medium": "http://www.cartoonbrew.com/wp-content/uploads/2013/09/minions-delay.jpg",
-            "small": "http://minionslovebananas.com/images/check-in-minion.jpg"
+            "small": "http://minionslovebananas.com/images/check-in-minion.jpg",
+            "attribution":"Copyright © 2015"
         }
     }

--- a/less/graphic.less
+++ b/less/graphic.less
@@ -1,0 +1,7 @@
+.graphic-widget-attribution {
+//this could be used to set the position to relative, and then graphic-attribution div to be absolute
+}
+.graphic-attribution {
+    font-size:0.75em;
+    line-height: 1em;
+}

--- a/templates/graphic.hbs
+++ b/templates/graphic.hbs
@@ -3,4 +3,7 @@
     <div class="graphic-widget component-widget">
         <img src="{{_graphic.src}}" alt="{{_graphic.alt}}" title="{{_graphic.title}}" data-large="{{_graphic.large}}" data-medium="{{_graphic.medium}}" data-small="{{_graphic.small}}"/>
     </div>
+    {{#if _showAttribution}}
+        <div class="graphic-attribution">{{{_graphic.attribution}}}</div>
+    {{/if}}    
 </div>

--- a/templates/graphic.hbs
+++ b/templates/graphic.hbs
@@ -1,6 +1,6 @@
 <div class="graphic-inner component-inner">
     {{> component this}}
-    <div class="graphic-widget component-widget">
+    <div class="graphic-widget component-widget{{#if _showAttribution}} graphic-widget-attribution{{/if}}">
         <img src="{{_graphic.src}}" alt="{{_graphic.alt}}" title="{{_graphic.title}}" data-large="{{_graphic.large}}" data-medium="{{_graphic.medium}}" data-small="{{_graphic.small}}"/>
     </div>
     {{#if _showAttribution}}


### PR DESCRIPTION
This adds simple attribution feature to the component. In the model you can turn it on/off with `_showAttribution` flag. The text (HTML enabled e.g. for links or other styling) is then pulled from the `attribution` property of the `_graphic` object.
Style adds 2 classes one for the container for the attribution div and for the actual attribution. Former can bse used to set this container to be positioned relative and then in the attribution class we can set custom position with `postion: absolute;`

e.g.

    .graphic-widget-attribution {
        //position: relative;
    }
    .graphic-attribution {
        //position: absolute;
        //bottom: 0;

        font-size:0.75em;
        line-height: 1em;
    }

