### PR TITLE
Defensive programming

### DIFF
--- a/js/adapt-contrib-graphic.js
+++ b/js/adapt-contrib-graphic.js
@@ -48,7 +48,8 @@ define(function(require) {
 
         resizeImage: function(width) {
             var imageWidth = width === 'medium' ? 'small' : width;
-            this.$('.graphic-widget img').attr('src', this.model.get('_graphic')[imageWidth]);
+            var imageSrc = (this.model.get('_graphic')) ? this.model.get('_graphic')[imageWidth] : '';
+            this.$('.graphic-widget img').attr('src', imageSrc);
 
             this.$('.graphic-widget').imageready(_.bind(function() {
                 this.setReadyStatus();


### PR DESCRIPTION
Checking that `this.model.get('_graphic')` is defined before using `this.model.get('_graphic')[imageWidth]` as src property of image tag. 

Prevents js error which caused an infinite loading spinner. 