### PR TITLE
Minor change to 'inview' binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ guide the learner’s interaction with the component.
 No known limitations.  
 
 ----------------------------
-**Version number:**  2.0.3   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.0.4   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 2.0  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-graphic/graphs/contributors)   
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-graphic",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-graphic",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-graphic%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/js/adapt-contrib-graphic.js
+++ b/js/adapt-contrib-graphic.js
@@ -13,8 +13,7 @@ define(function(require) {
         },
 
         postRender: function() {
-            this.resizeImage(Adapt.device.screenSize);
-            this.$('.component-widget').on('inview', _.bind(this.inview, this));
+            this.resizeImage(Adapt.device.screenSize, true);
         },
 
         // Used to check if the graphic should reset on revisit
@@ -46,13 +45,25 @@ define(function(require) {
             }
         },
 
-        resizeImage: function(width) {
+        remove: function() {
+          // Remove any 'inview' listener attached.
+          this.$('.component-widget').off('inview');
+
+          ComponentView.prototype.remove.apply(this, arguments);
+        },
+
+        resizeImage: function(width, inPostRender) {
             var imageWidth = width === 'medium' ? 'small' : width;
             var imageSrc = (this.model.get('_graphic')) ? this.model.get('_graphic')[imageWidth] : '';
             this.$('.graphic-widget img').attr('src', imageSrc);
 
             this.$('.graphic-widget').imageready(_.bind(function() {
                 this.setReadyStatus();
+
+                if (inPostRender) {
+                    // Bind 'inview' once the image is ready.
+                    this.$('.component-widget').on('inview', _.bind(this.inview, this));
+                }
             }, this));
         }
     });

--- a/js/adapt-contrib-graphic.js
+++ b/js/adapt-contrib-graphic.js
@@ -52,7 +52,7 @@ define(function(require) {
           ComponentView.prototype.remove.apply(this, arguments);
         },
 
-        resizeImage: function(width, inPostRender) {
+        resizeImage: function(width, setupInView) {
             var imageWidth = width === 'medium' ? 'small' : width;
             var imageSrc = (this.model.get('_graphic')) ? this.model.get('_graphic')[imageWidth] : '';
             this.$('.graphic-widget img').attr('src', imageSrc);
@@ -60,7 +60,7 @@ define(function(require) {
             this.$('.graphic-widget').imageready(_.bind(function() {
                 this.setReadyStatus();
 
-                if (inPostRender) {
+                if (setupInView) {
                     // Bind 'inview' once the image is ready.
                     this.$('.component-widget').on('inview', _.bind(this.inview, this));
                 }


### PR DESCRIPTION
This corrects an issue with completion which is especially noticable on Safari on iOS devices.

- Moved the 'inview' binding to the imageready() callback, which corrects the issue with graphics marking completed before they're actually visible
- Tidied up removal of 'inview' listeners on remove