### PR TITLE
Fix: Fix _url.title property name (fixes #104)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -92,7 +92,7 @@
           "type": "string",
           "required": false,
           "default": "",
-          "Title": "URL",
+          "title": "URL",
           "inputType": "Text",
           "validators": [],
           "help": "When the graphic is selected this is the url it will follow."


### PR DESCRIPTION
Fixes #104 

### Fix
* Fix `_url.title` property name. Previous property name of `_url.Title` was invalid.