### PR TITLE
Fix: Add empty string as valid _target value, remove target property if value is not set (fix #106)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -100,12 +100,12 @@
         "_target": {
           "type": "string",
           "required": false,
-          "enum": ["_blank", "_self", "_parent", "_top"],
+          "enum": ["", "_blank", "_self", "_parent", "_top"],
           "default": "_blank",
           "title": "Target attribute",
           "inputType": {
             "type": "Select",
-            "options": ["_blank", "_self", "_parent", "_top"]
+            "options": ["", "_blank", "_self", "_parent", "_top"]
           },
           "validators": [],
           "help": "This targets where to open the link. Acceptable values are '_blank' (opens the linked document in a new window or tab), '_parent' (opens the linked document in the parent frame), '_top' (opens the linked document in the full body of the window) or '_self' (opens the linked document in the same frame as it was selected. If no value is set, the default is '_blank'."

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -96,6 +96,7 @@
               "title": "Target attribute",
               "description": "This targets where to open the link. Acceptable values are '_blank' (opens the linked document in a new window or tab), '_parent' (opens the linked document in the parent frame), '_top' (opens the linked document in the full body of the window) or '_self' (opens the linked document in the same frame as it was selected. If no value is set, the default is '_blank'.",
               "enum": [
+                "", 
                 "_blank",
                 "_self",
                 "_parent",

--- a/templates/graphic.jsx
+++ b/templates/graphic.jsx
@@ -38,7 +38,7 @@ export default function Graphic(props) {
 
         <LinkWrapper
           href = {_graphic._url}
-          target = {_graphic._target}
+          target = {_graphic._target || null}
           className = 'graphic__link js-graphic-link'
           role = 'link'
         >


### PR DESCRIPTION
Fixes #106 

### Fix
* Add empty string as valid `_target` value in the schemas
* Remove `target` attribute from the link element if a value is not set