### PR TITLE
Fix: remove ariaRegion default (fixes #113)

### DIFF
--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -24,7 +24,7 @@
                     "ariaRegion": {
                       "type": "string",
                       "title": "ARIA region",
-                      "default": "Graphic",
+                      "default": "",
                       "_adapt": {
                         "translatable": true
                       }


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-graphic/issues/113

### Fix
* ARIA regions are used to describe the component type. It makes sense we do this for interactive components but it's a nuisance for images. Only images with alt text provided should be announced by screen readers.


