### PR TITLE
Update: Make large and small properties optional (Fixes #116)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -65,7 +65,7 @@
         },
         "large": {
           "type": "string",
-          "required": true,
+          "required": false,
           "default": "",
           "inputType": "Asset:image",
           "validators": ["required"],
@@ -73,7 +73,7 @@
         },
         "small": {
           "type": "string",
-          "required": true,
+          "required": false,
           "default": "",
           "inputType": "Asset:image",
           "validators": ["required"],

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -33,10 +33,6 @@
           "type": "object",
           "title": "Graphic",
           "default": {},
-          "required": [
-            "large",
-            "small"
-          ],
           "properties": {
             "alt": {
               "type": "string",


### PR DESCRIPTION
Fix #116 

### Fix
* Make both `_graphic.large` and `_graphic.small` optional.